### PR TITLE
Add events page + CSS

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,6 +19,7 @@
             <ul>
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html" class="active">About Us</a></li>
+                <li><a href="events.html">Events</a></li>
                 <li><a href="whatwearedoing.html">What We're Doing</a></li>
                 <li><a href="sponsors.html">Sponsors</a></li>
                 <li><a href="conference.html">Conference</a></li>

--- a/conference.html
+++ b/conference.html
@@ -19,6 +19,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="whatwearedoing.html">What We're Doing</a></li>
+                <li><a href="events.html">Events</a></li>
                 <li><a href="sponsors.html">Sponsors</a></li>
                 <li><a href="conference.html" class="active">Conference</a></li>
                 <li><a href="contact.html">Contact Us</a></li>

--- a/contact.html
+++ b/contact.html
@@ -19,6 +19,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="whatwearedoing.html">What We're Doing</a></li>
+                <li><a href="events.html">Events</a></li>
                 <li><a href="sponsors.html">Sponsors</a></li>
                 <li><a href="conference.html">Conference</a></li>
                 <li><a href="contact.html" class="active">Contact Us</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -393,3 +393,48 @@ nav a:hover, nav a.active {
     text-align: center;
     padding: 30px;
 }
+
+/* Events Page Styles */
+.events-container {
+    max-width: 1000px;
+    margin: 100px auto 50px;
+    padding: 0 20px;
+    text-align: center;
+}
+
+.events-header {
+    margin-bottom: 40px;
+}
+
+.events-header h1 {
+    font-size: 42px;
+    color: #333;
+    margin-bottom: 15px;
+}
+
+.events-subheading {
+    font-size: 18px;
+    color: #666;
+    max-width: 700px;
+    margin: 0 auto;
+    line-height: 1.5;
+}
+
+.calendar-container {
+    display: flex;
+    justify-content: center;
+    margin: 30px 0 60px;
+}
+
+.calendar-container iframe {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    border-radius: 8px;
+    max-width: 100%;
+}
+
+@media (max-width: 850px) {
+    .calendar-container iframe {
+        width: 100%;
+        height: 500px;
+    }
+}

--- a/events.html
+++ b/events.html
@@ -2,12 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Home | Your Organization Name</title>
+    <title>Events | NSBE USF</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 
-    <!-- Header -->
     <header>
         <div class="logo">
             <a href="index.html"><img src="images/usflogo.png" alt="Organization Logo"></a>
@@ -17,10 +16,10 @@
         </div>
         <nav>
             <ul>
-                <li><a href="index.html" class="active">Home</a></li>
+                <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="whatwearedoing.html">What We're Doing</a></li>
-                <li><a href="events.html">Events</a></li>
+                <li><a href="events.html" class="active">Events</a></li>
                 <li><a href="sponsors.html">Sponsors</a></li>
                 <li><a href="conference.html">Conference</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
@@ -28,36 +27,20 @@
         </nav>
     </header>
 
-    <div class="hero-image-container">
-        <img src="images/5V6A6153.jpg" alt="Image Description">
+    <div class="events-container">
+        <div class="events-header">
+            <h1>Events</h1>
+            <p class="events-subheading">Join us at our upcoming events this semester! This calendar contains all our activities - we'd love to see you there.</p>
+        </div>
+
+        <div class="calendar-container">
+            <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FNew_York&showTitle=1&showNav=1&showDate=1&showPrint=0&showTabs=1&showCalendars=0&src=ZW4udXNhI2hvbGlkYXlAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&color=%230B8043" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        </div>
     </div>
-    <!-- Hero Section -->
-    <section class="hero">
-        <div class="hero-content">
-            <h1>Our Mission</h1>
-            <p>To increase the number of culturally responsible Black engineers, who excel academically, succeed professionally, and positively impact the community. </p>
-            <p>The National Society of Black Engineers (NSBE) with more than 19,000 members is the largest student-managed organization in the country. NSBE's mission is to increase the number of culturally responsible Black engineers who excel academically, succeed professionally and positively impact the community. NSBE is comprised of more than 270 chapters on college and university campuses, 75 Alumni Extension chapters nationwide and 75 Pre-College chapters. These chapters are geographically divided into six regions.</p>
-            <a href="about.html" class="button">Learn More</a>
-            <a href="contact.html" class="button">Join Us</a>
-        </div>
-    </section>
 
-    <!-- Highlights Section -->
-    <section class="highlights">
-        <div class="highlight">
-            <h2>Featured Event</h2>
-            <p class="highlight-text">Check our Instagram for upcoming events!</p>
-            <a href="https://www.instagram.com/usfnsbe?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="button">Learn More</a>
-        </div>
-        <div class="highlight">
-            <h2>Featured Project</h2>
-            <p class="highlight-text">We are currently working on our walk for education! Fill out the form below to show interest!</p>
-            <a href="https://www.instagram.com/usfnsbe?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="button">Learn More</a>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <footer class="modern-footer">
+    <!-- Include Footer -->
+     <!-- Footer -->
+     <footer class="modern-footer">
         <div class="footer-container">
             <div class="footer-section">
                 <h3>Quick Links</h3>
@@ -95,6 +78,5 @@
             <p>&copy; 2024 NSBE USF Chapter. All rights reserved.</p>
         </div>
     </footer>
-
 </body>
 </html>

--- a/sponsors.html
+++ b/sponsors.html
@@ -19,6 +19,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="whatwearedoing.html">What We're Doing</a></li>
+                <li><a href="events.html">Events</a></li>
                 <li><a href="sponsors.html" class="active">Sponsors</a></li>
                 <li><a href="conference.html">Conference</a></li>
                 <li><a href="contact.html">Contact Us</a></li>

--- a/whatwearedoing.html
+++ b/whatwearedoing.html
@@ -19,6 +19,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="whatwearedoing.html" class="active">What We're Doing</a></li>
+                <li><a href="events.html">Events</a></li>
                 <li><a href="sponsors.html">Sponsors</a></li>
                 <li><a href="conference.html">Conference</a></li>
                 <li><a href="contact.html">Contact Us</a></li>


### PR DESCRIPTION
## Add Events Page with Embedded Google Calendar

**Key Changes:**

* **Events Page:** Created a new "Events" page to display upcoming NSBE USF events.
* **Embedded Calendars:** [Google's official guide](https://support.google.com/calendar/answer/41207?hl=en).
<img width="1230" alt="Screenshot 2025-02-25 at 3 27 52 PM" src="https://github.com/user-attachments/assets/22fb3360-a857-4295-9106-faebd78cf95f" />
* NOTE: Mock calendar; can be replaced with NSBE's actual GCAL which handles their event info
